### PR TITLE
Add `psr/http-message` 2.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   ],
   "require": {
     "php": ">=7.4",
-    "psr/http-message": "^1.0",
+    "psr/http-message": "^1.0||^2.0",
     "guzzlehttp/guzzle": "^7.2",
     "ext-libxml": "*",
     "ext-simplexml": "*",


### PR DESCRIPTION
```shell
  Problem 1
    - Root composer.json requires overtrue/flysystem-cos ^4.0 -> satisfiable by overtrue/flysystem-cos[4.0.0, 4.0.1].
    - overtrue/flysystem-cos[4.0.0, ..., 4.0.1] require overtrue/qcloud-cos-client ^1.0.0 -> satisfiable by overtrue/qcloud-cos-client[1.0.0, ..., 1.x-dev].
    - overtrue/qcloud-cos-client[1.0.0, ..., 1.x-dev] require psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but these were not loaded, likely because it conflicts with another require.


Installation failed, reverting ./composer.json and ./composer.lock to their original content.
Error: Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Root composer.json requires overtrue/flysystem-cos ^4.0 -> satisfiable by overtrue/flysystem-cos[4.0.0, 4.0.1].
    - overtrue/flysystem-cos[4.0.0, ..., 4.0.1] require overtrue/qcloud-cos-client ^1.0.0 -> satisfiable by overtrue/qcloud-cos-client[1.0.0, ..., 1.x-dev].
    - overtrue/qcloud-cos-client[1.0.0, ..., 1.x-dev] require psr/http-message ^1.0 -> found psr/http-message[1.0, 1.0.1, 1.1] but these were not loaded, likely because it conflicts with another require.
```

与`aws/aws-sdk-php`依赖冲突了。

https://github.com/hyperf/hyperf/actions/runs/13087040367/job/36519426377?pr=7276