### PR TITLE
fix: 修复部分新系统中不存在 PRC 时区的问题。

### DIFF
--- a/src/Signature.php
+++ b/src/Signature.php
@@ -114,7 +114,7 @@ class Signature
     {
         $timezone = \date_default_timezone_get();
 
-        date_default_timezone_set('PRC');
+        date_default_timezone_set('Asia/Shanghai');
 
         $signTime = \sprintf('%s;%s', time() - 60, strtotime($expires ?? '+60 minutes'));
 


### PR DESCRIPTION
`date_default_timezone_set(): Timezone ID 'PRC' is invalid`

ChatGPT: 是由于 PHP 在当前的环境中不再支持使用 'PRC' 作为时区 ID（它是中国大陆旧的别名，部分系统中已废弃或未启用）。

```
cat /etc/issue
Ubuntu 24.04.2 LTS \n \l
```

```
ls -al /usr/share/zoneinfo/
total 288
drwxr-xr-x 1 root root   4096 May 10 19:40 .
drwxr-xr-x 1 root root   4096 May  7 01:21 ..
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Africa
drwxr-xr-x 6 root root   4096 Mar 21 05:56 America
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Antarctica
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Arctic
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Asia
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Atlantic
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Australia
-rw-r--r-- 1 root root   2094 Jan 30 21:33 CET
-rw-r--r-- 1 root root   2310 Jan 30 21:33 CST6CDT
-rw-r--r-- 1 root root   1908 Jan 30 21:33 EET
-rw-r--r-- 1 root root    114 Jan 30 21:33 EST
-rw-r--r-- 1 root root   2310 Jan 30 21:33 EST5EDT
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Etc
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Europe
-rw-r--r-- 1 root root    116 Jan 30 21:33 Factory
lrwxrwxrwx 1 root root      7 Jan 30 21:33 GMT -> Etc/GMT
-rw-r--r-- 1 root root    115 Jan 30 21:33 HST
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Indian
-rw-r--r-- 1 root root   4791 Sep  6  2023 iso3166.tab
-rw-r--r-- 1 root root   3253 Jan 30 21:33 leapseconds
-rw-r--r-- 1 root root   5064 Jul 29  2024 leap-seconds.list
lrwxrwxrwx 1 root root     14 Jan 30 21:33 localtime -> /etc/localtime
-rw-r--r-- 1 root root   2094 Jan 30 21:33 MET
-rw-r--r-- 1 root root    114 Jan 30 21:33 MST
-rw-r--r-- 1 root root   2310 Jan 30 21:33 MST7MDT
drwxr-xr-x 2 root root   4096 Mar 21 05:56 Pacific
lrwxrwxrwx 1 root root     16 Jan 30 21:33 posixrules -> America/New_York
-rw-r--r-- 1 root root   2310 Jan 30 21:33 PST8PDT
-rw-r--r-- 1 root root 116137 Jan 30 21:33 tzdata.zi
lrwxrwxrwx 1 root root      7 Jan 30 21:33 UTC -> Etc/UTC
-rw-r--r-- 1 root root   1905 Jan 30 21:33 WET
-rw-r--r-- 1 root root  17510 Jul  3  2024 zone1970.tab
-rw-r--r-- 1 root root   8101 May 25  2024 zonenow.tab
-rw-r--r-- 1 root root  18775 Jul  3  2024 zone.tab
```

环境是 docker 的，laravel sail php8.4 环境。

![image](https://github.com/user-attachments/assets/a7f97cf0-918c-4cb1-ab07-af7cc3655df8)

![image](https://github.com/user-attachments/assets/3fbe2b5b-8948-4ef3-a53f-c8a8e8020a03)

![image](https://github.com/user-attachments/assets/b01c1d4c-a2fc-4cac-a4f9-477f1efa8e52)

![image](https://github.com/user-attachments/assets/5f4445bd-a254-411d-9c40-1067bff1b141)







